### PR TITLE
v1: API client implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Text editor and miscellaneous files
+*.sw[op]

--- a/example_test.go
+++ b/example_test.go
@@ -1,15 +1,4 @@
-# googshorty
-Google URL shortener API client
-
-## Requirements
-In your environment, please set variable `GOOGLE_URL_SHORTENER_API_KEY`
-
-## Usage
-Please see file [example_test.go](./example_test.go) or follow below
-
-* Preamble:
-```go
-package main 
+package googshorty_test
 
 import (
 	"fmt"
@@ -17,11 +6,8 @@ import (
 
 	"github.com/orijtech/googshorty/v1"
 )
-```
 
-* Shorten a URL
-```go
-func main() {
+func Example_client_Shorten() {
 	client, err := googshorty.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -34,11 +20,8 @@ func main() {
 
 	fmt.Printf("ShortURL: %q\n", details.ShortURL)
 }
-```
 
-* Expand a shortened URL
-```go
-func main() {
+func Example_client_Expand() {
 	client, err := googshorty.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -51,11 +34,8 @@ func main() {
 
 	fmt.Printf("LongURL: %q\n", details.LongURL)
 }
-```
 
-* Lookup analytics for a shortened URL
-```go
-func main() {
+func Example_client_LookupAnalytics() {
 	client, err := googshorty.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -75,4 +55,3 @@ func main() {
 		fmt.Printf("In Last Two hours: %#v\n", analytics.WithinLast2Hours)
 	}
 }
-```

--- a/v1/client.go
+++ b/v1/client.go
@@ -1,0 +1,66 @@
+package googshorty
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/orijtech/otils"
+)
+
+type Client struct {
+	sync.RWMutex
+	_apiKey string
+
+	rt http.RoundTripper
+}
+
+func (c *Client) apiKey() string {
+	c.RLock()
+	defer c.RUnlock()
+	return c._apiKey
+}
+
+func (c *Client) SetHTTPRoundTripper(rt http.RoundTripper) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.rt = rt
+}
+
+func (c *Client) httpClient() *http.Client {
+	c.RLock()
+	rt := c.rt
+	c.RUnlock()
+
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	return &http.Client{Transport: rt}
+}
+
+const (
+	envAPIClientKeyKey = "GOOGLE_URL_SHORTENER_API_KEY"
+)
+
+func NewClient(apiKeys ...string) (*Client, error) {
+	apiKey := otils.FirstNonEmptyString(apiKeys...)
+	if apiKey != "" {
+		return &Client{_apiKey: apiKey}, nil
+	}
+
+	// Otherwise fallback to retrieving the key from the environment
+	return NewClientFromEnv()
+}
+
+var errUnsetEnvClientKey = fmt.Errorf("could not find %q in your environment", envAPIClientKeyKey)
+
+func NewClientFromEnv() (*Client, error) {
+	apiKey := os.Getenv(envAPIClientKeyKey)
+	if apiKey == "" {
+		return nil, errUnsetEnvClientKey
+	}
+	return &Client{_apiKey: apiKey}, nil
+}

--- a/v1/googshorty.go
+++ b/v1/googshorty.go
@@ -1,0 +1,165 @@
+package googshorty
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/orijtech/otils"
+)
+
+type URLDetails struct {
+	Kind          string `json:"kind"`
+	ShortURL      string `json:"id"`
+	LongURL       string `json:"longUrl,omitempty"`
+	StatusMessage string `json:"status"`
+}
+
+type CountIDPair struct {
+	Count uint64 `json:"count,string"`
+	ID    string `json:"id"`
+}
+
+const (
+	baseURL = "https://www.googleapis.com/urlshortener/v1"
+)
+
+var (
+	errBlankContent = errors.New("expecting non-blank content")
+)
+
+func (c *Client) Shorten(longURL string) (*URLDetails, error) {
+	// Note that Google itself as of
+	// Tue  9 May 2017 22:23:45 MDT
+	// allows any kind of value shortened
+	// so being strict here is of no value.
+	// e.g see:
+	//    `https://goo.gl/f0RWxs` which I set to just `github`
+	// When they become strict, then sure uncomment this code.
+	// parsedURL, err := url.Parse(longURL)
+	// _, err := url.Parse(longURL)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// The closest to validation we can do here is
+	// to reject purely whitespace and blank URLs.
+	if strings.TrimSpace(longURL) == "" {
+		return nil, errBlankContent
+	}
+
+	blob, err := json.Marshal(&URLDetails{LongURL: longURL})
+	if err != nil {
+		return nil, err
+	}
+	fullURL := fmt.Sprintf("%s/url?key=%s", baseURL, c.apiKey())
+	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	blob, _, err = c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+	udetails := new(URLDetails)
+	if err := json.Unmarshal(blob, udetails); err != nil {
+		return nil, err
+	}
+	return udetails, nil
+}
+
+func (c *Client) doAuthAndReq(req *http.Request) ([]byte, http.Header, error) {
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	if !otils.StatusOK(res.StatusCode) {
+		msg := res.Status
+		if res.Body != nil {
+			slurp, _ := ioutil.ReadAll(res.Body)
+			if len(slurp) > 3 {
+				msg = string(slurp)
+			}
+		}
+		return nil, res.Header, errors.New(msg)
+	}
+
+	slurp, err := ioutil.ReadAll(res.Body)
+	return slurp, res.Header, err
+}
+
+func (c *Client) Expand(shortURL string) (*URLDetails, error) {
+	fullURL := fmt.Sprintf("%s/url?shortUrl=%s&key=%s", baseURL, shortURL, c.apiKey())
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	slurp, _, err := c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	uinf := new(URLDetails)
+	if err := json.Unmarshal(slurp, uinf); err != nil {
+		return nil, err
+	}
+	return uinf, nil
+}
+
+type Analytics struct {
+	Kind      string     `json:"kind"`
+	ID        string     `json:"id"`
+	Status    string     `json:"status"`
+	CreatedAt *time.Time `json:"created"`
+
+	Analytics *Analytic `json:"analytics"`
+}
+
+type Analytic struct {
+	AllTime          *AnalyticDetails `json:"allTime"`
+	WithinLastMonth  *AnalyticDetails `json:"month"`
+	WithinLastWeek   *AnalyticDetails `json:"week"`
+	WithinLastDay    *AnalyticDetails `json:"day"`
+	WithinLast2Hours *AnalyticDetails `json:"twoHours"`
+}
+
+type AnalyticDetails struct {
+	ShortURLClicks uint64         `json:"shortUrlClicks,string"`
+	LongURLClicks  uint64         `json:"longUrlClicks,string"`
+	Referrers      []*CountIDPair `json:"referrers"`
+	Countries      []*CountIDPair `json:"countries"`
+	Browsers       []*CountIDPair `json:"browsers"`
+	Platforms      []*CountIDPair `json:"platforms"`
+}
+
+var errUnimplemented = errors.New("unimplemented")
+
+func (c *Client) LookupAnalytics(shortURL string) (*Analytics, error) {
+	fullURL := fmt.Sprintf("%s/url?shortUrl=%s&key=%s&projection=FULL", baseURL, shortURL, c.apiKey())
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	slurp, _, err := c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	analytics := new(Analytics)
+	if err := json.Unmarshal(slurp, analytics); err != nil {
+		return nil, err
+	}
+	return analytics, nil
+}

--- a/v1/googshorty_test.go
+++ b/v1/googshorty_test.go
@@ -1,0 +1,411 @@
+package googshorty_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orijtech/googshorty/v1"
+)
+
+func TestExpand(t *testing.T) {
+	client, err := googshorty.NewClient(apiKey1)
+	if err != nil {
+		t.Fatalf("initializing the client: %v", err)
+	}
+	client.SetHTTPRoundTripper(&backend{route: expandRoute})
+
+	tests := [...]struct {
+		shortURL string
+		want     *googshorty.URLDetails
+		wantErr  bool
+	}{
+		0: {
+			shortURL: "https://goo.gl/Zu6ATj",
+			want:     urlDetailsFromFile("orijtech"),
+		},
+
+		1: {
+			shortURL: "https://goo.gl/5ycdVx",
+			want:     urlDetailsFromFile("medisa"),
+		},
+
+		// Test malformed URLs
+		2: {
+			shortURL: "",
+			wantErr:  true,
+		},
+		3: {
+			shortURL: "     ",
+			wantErr:  true,
+		},
+		4: {
+			// Unknown
+			shortURL: fmt.Sprintf("%v", time.Now().Unix()),
+			wantErr:  true,
+		},
+	}
+
+	for i, tt := range tests {
+		udetails, err := client.Expand(tt.shortURL)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d expecting non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d err: %v", i, err)
+			continue
+		}
+
+		if udetails == nil {
+			t.Errorf("#%d expecting url details back", i)
+			continue
+		}
+
+		gotBlob, wantBlob := jsonMarshal(udetails), jsonMarshal(tt.want)
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("#%d\ngot:  %s\nwant: %s", i, gotBlob, wantBlob)
+		}
+	}
+}
+
+func TestLookupAnalytics(t *testing.T) {
+	client, err := googshorty.NewClient(apiKey1)
+	if err != nil {
+		t.Fatalf("initializing the client: %v", err)
+	}
+	client.SetHTTPRoundTripper(&backend{route: analyticsRoute})
+
+	tests := [...]struct {
+		url     string
+		want    *googshorty.Analytics
+		wantErr bool
+	}{
+		0: {
+			url:  "https://goo.gl/XRdHKo",
+			want: analyticsFromFile("googshorty"),
+		},
+
+		// Test malformed URLs
+		1: {
+			url:     "",
+			wantErr: true,
+		},
+		2: {
+			url:     "     ",
+			wantErr: true,
+		},
+		3: {
+			// Not a recognized URL
+			url:     "/v2/flux",
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		analytics, err := client.LookupAnalytics(tt.url)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d expecting non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d err: %v", i, err)
+			continue
+		}
+
+		if analytics == nil {
+			t.Errorf("#%d expecting analytics back", i)
+			continue
+		}
+
+		gotBlob, wantBlob := jsonMarshal(analytics), jsonMarshal(tt.want)
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("#%d\ngot:  %s\nwant: %s", i, gotBlob, wantBlob)
+		}
+	}
+}
+
+func TestShorten(t *testing.T) {
+	client, err := googshorty.NewClient(apiKey1)
+	if err != nil {
+		t.Fatalf("initializing the client: %v", err)
+	}
+	client.SetHTTPRoundTripper(&backend{route: shortenRoute})
+
+	tests := [...]struct {
+		longURL string
+		want    *googshorty.URLDetails
+		wantErr bool
+	}{
+		0: {
+			longURL: "https://orijtech.com/",
+			want:    urlDetailsFromFile("orijtech"),
+		},
+
+		1: {
+			longURL: "https://medisa.orijtech.com/",
+			want:    urlDetailsFromFile("medisa"),
+		},
+
+		// Test malformed URLs
+		2: {
+			longURL: "",
+			wantErr: true,
+		},
+		3: {
+			longURL: "     ",
+			wantErr: true,
+		},
+		4: {
+			// Not a recognized URL
+			longURL: "/v2/flux",
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		udetails, err := client.Shorten(tt.longURL)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d expecting non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d err: %v", i, err)
+			continue
+		}
+
+		if udetails == nil {
+			t.Errorf("#%d expecting url details back", i)
+			continue
+		}
+
+		gotBlob, wantBlob := jsonMarshal(udetails), jsonMarshal(tt.want)
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("#%d\ngot:  %s\nwant: %s", i, gotBlob, wantBlob)
+		}
+	}
+}
+
+func urlDetailsPath(id string) string {
+	return fmt.Sprintf("./testdata/url-details-%s.json", id)
+}
+
+func urlDetailsFromFile(id string) *googshorty.URLDetails {
+	path := urlDetailsPath(id)
+	save := new(googshorty.URLDetails)
+	if err := jsonDeserializeFromPath(path, save); err != nil {
+		return nil
+	}
+	return save
+}
+
+func analyticsPath(id string) string {
+	return fmt.Sprintf("./testdata/analytics-%s.json", id)
+}
+
+func analyticsFromFile(id string) *googshorty.Analytics {
+	path := analyticsPath(id)
+	save := new(googshorty.Analytics)
+	if err := jsonDeserializeFromPath(path, save); err != nil {
+		return nil
+	}
+	return save
+}
+
+func jsonDeserializeFromPath(path string, save interface{}) error {
+	blob, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(blob, save)
+}
+
+func jsonMarshal(v interface{}) []byte {
+	blob, _ := json.Marshal(v)
+	return blob
+}
+
+type backend struct {
+	route string
+}
+
+var _ http.RoundTripper = (*backend)(nil)
+
+func (b *backend) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch b.route {
+	case shortenRoute:
+		return b.shortenRoundTrip(req)
+	case expandRoute:
+		return b.expandRoundTrip(req)
+	case analyticsRoute:
+		return b.analyticsRoundTrip(req)
+	default:
+		msg := fmt.Sprintf("%s is an unknown route", b.route)
+		return makeResp(msg, http.StatusNotFound, nil), nil
+	}
+}
+
+var hostToShortURLMapping = map[string]string{
+	"orijtech.com":        "orijtech",
+	"medisa.orijtech.com": "medisa",
+
+	"Zu6ATj": "orijtech",
+	"5ycdVx": "medisa",
+
+	"XRdHKo": "googshorty",
+}
+
+func (b *backend) expandRoundTrip(req *http.Request) (*http.Response, error) {
+	if badAuthResp, err := b.checkAuthAndMethod(req, "GET"); err != nil || badAuthResp != nil {
+		return badAuthResp, err
+	}
+	query := req.URL.Query()
+	shortURL := strings.TrimSpace(query.Get("shortUrl"))
+	if shortURL == "" {
+		msg := `expecting "shortUrl" in the query string`
+		return makeResp(msg, http.StatusBadRequest, nil), nil
+	}
+
+	// Note that Google itself as of
+	// Tue  9 May 2017 22:23:45 MDT
+	// allows any kind of value shortened
+	// so being strict here is of no value.
+	// e.g see:
+	//    `https://goo.gl/f0RWxs` which I set to just `github`
+	// When they become strict, then sure uncomment this code.
+	// if err != nil {
+	// 	return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	// }
+	key := shortURL
+	parsedURL, err := url.Parse(shortURL)
+	if err == nil && parsedURL != nil {
+		key = strings.TrimLeft(parsedURL.Path, "/")
+	}
+
+	shortURLID := hostToShortURLMapping[key]
+	diskPath := urlDetailsPath(shortURLID)
+	return makeResponseFromFile(diskPath)
+}
+
+func (b *backend) analyticsRoundTrip(req *http.Request) (*http.Response, error) {
+	if badAuthResp, err := b.checkAuthAndMethod(req, "GET"); err != nil || badAuthResp != nil {
+		return badAuthResp, err
+	}
+	query := req.URL.Query()
+	shortURL := strings.TrimSpace(query.Get("shortUrl"))
+	if shortURL == "" {
+		msg := `expecting "shortUrl" in the query string`
+		return makeResp(msg, http.StatusBadRequest, nil), nil
+	}
+
+	key := shortURL
+	parsedURL, err := url.Parse(shortURL)
+	if err == nil && parsedURL != nil {
+		key = strings.TrimLeft(parsedURL.Path, "/")
+	}
+
+	shortURLID := hostToShortURLMapping[key]
+	diskPath := analyticsPath(shortURLID)
+	return makeResponseFromFile(diskPath)
+
+}
+
+func (b *backend) shortenRoundTrip(req *http.Request) (*http.Response, error) {
+	if badAuthResp, err := b.checkAuthAndMethod(req, "POST"); err != nil || badAuthResp != nil {
+		return badAuthResp, err
+	}
+	slurp, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	recv := make(map[string]string)
+	if err := json.Unmarshal(slurp, &recv); err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	longURL := recv["longUrl"]
+
+	// Note that Google itself as of
+	// Tue  9 May 2017 22:23:45 MDT
+	// allows any kind of value shortened
+	// so being strict here is of no value.
+	// e.g see:
+	//    `https://goo.gl/f0RWxs` which I set to just `github`
+	// When they become strict, then sure uncomment this code.
+	// if err != nil {
+	// 	return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	// }
+	parsedURL, err := url.Parse(longURL)
+	key := longURL
+	if err == nil && parsedURL != nil {
+		key = parsedURL.Host
+	}
+
+	shortURLID := hostToShortURLMapping[key]
+	diskPath := urlDetailsPath(shortURLID)
+	return makeResponseFromFile(diskPath)
+}
+
+func makeResponseFromFile(path string) (*http.Response, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return makeResp(err.Error(), http.StatusInternalServerError, nil), nil
+	}
+	return makeResp("200 OK", http.StatusOK, f), nil
+}
+
+var knownAPIKeys = map[string]bool{
+	apiKey1: true,
+}
+
+func authorizedAPIKey(apiKey string) bool {
+	_, authorized := knownAPIKeys[apiKey]
+	return authorized
+}
+
+func (b *backend) checkAuthAndMethod(req *http.Request, wantMethod string) (*http.Response, error) {
+	if got, want := req.Method, wantMethod; got != want {
+		msg := fmt.Sprintf("got method %q, want %q", got, want)
+		return makeResp(msg, http.StatusMethodNotAllowed, nil), nil
+	}
+
+	query := req.URL.Query()
+	apiKey := strings.TrimSpace(query.Get("key"))
+	if !authorizedAPIKey(apiKey) {
+		return makeResp("unauthorized api key", http.StatusUnauthorized, nil), nil
+	}
+	return nil, nil
+}
+
+func makeResp(status string, code int, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		Status:     status,
+		StatusCode: code,
+		Body:       body,
+		Header:     make(http.Header),
+	}
+}
+
+const (
+	shortenRoute   = "shorten"
+	expandRoute    = "expand"
+	analyticsRoute = "analytics"
+
+	apiKey1 = "api-key-1"
+)

--- a/v1/testdata/analytics-googshorty.json
+++ b/v1/testdata/analytics-googshorty.json
@@ -1,0 +1,159 @@
+{
+ "kind": "urlshortener#url",
+ "id": "https://goo.gl/XRdHKo",
+ "longUrl": "https://github.com/orijtech/googshorty",
+ "status": "OK",
+ "created": "2017-05-10T05:12:18.170+00:00",
+ "analytics": {
+  "allTime": {
+   "shortUrlClicks": "3",
+   "longUrlClicks": "3",
+   "referrers": [
+    {
+     "count": "3",
+     "id": "unknown"
+    }
+   ],
+   "browsers": [
+    {
+     "count": "1",
+     "id": "Chrome"
+    },
+    {
+     "count": "1",
+     "id": "Firefox"
+    },
+    {
+     "count": "1",
+     "id": "Safari"
+    }
+   ],
+   "platforms": [
+    {
+     "count": "3",
+     "id": "Macintosh"
+    }
+   ]
+  },
+  "month": {
+   "shortUrlClicks": "3",
+   "longUrlClicks": "3",
+   "referrers": [
+    {
+     "count": "3",
+     "id": "unknown"
+    }
+   ],
+   "browsers": [
+    {
+     "count": "1",
+     "id": "Chrome"
+    },
+    {
+     "count": "1",
+     "id": "Firefox"
+    },
+    {
+     "count": "1",
+     "id": "Safari"
+    }
+   ],
+   "platforms": [
+    {
+     "count": "3",
+     "id": "Macintosh"
+    }
+   ]
+  },
+  "week": {
+   "shortUrlClicks": "3",
+   "longUrlClicks": "3",
+   "referrers": [
+    {
+     "count": "3",
+     "id": "unknown"
+    }
+   ],
+   "browsers": [
+    {
+     "count": "1",
+     "id": "Chrome"
+    },
+    {
+     "count": "1",
+     "id": "Firefox"
+    },
+    {
+     "count": "1",
+     "id": "Safari"
+    }
+   ],
+   "platforms": [
+    {
+     "count": "3",
+     "id": "Macintosh"
+    }
+   ]
+  },
+  "day": {
+   "shortUrlClicks": "3",
+   "longUrlClicks": "3",
+   "referrers": [
+    {
+     "count": "3",
+     "id": "unknown"
+    }
+   ],
+   "browsers": [
+    {
+     "count": "1",
+     "id": "Chrome"
+    },
+    {
+     "count": "1",
+     "id": "Firefox"
+    },
+    {
+     "count": "1",
+     "id": "Safari"
+    }
+   ],
+   "platforms": [
+    {
+     "count": "3",
+     "id": "Macintosh"
+    }
+   ]
+  },
+  "twoHours": {
+   "shortUrlClicks": "3",
+   "longUrlClicks": "3",
+   "referrers": [
+    {
+     "count": "3",
+     "id": "unknown"
+    }
+   ],
+   "browsers": [
+    {
+     "count": "1",
+     "id": "Chrome"
+    },
+    {
+     "count": "1",
+     "id": "Firefox"
+    },
+    {
+     "count": "1",
+     "id": "Safari"
+    }
+   ],
+   "platforms": [
+    {
+     "count": "3",
+     "id": "Macintosh"
+    }
+   ]
+  }
+ }
+}

--- a/v1/testdata/url-details-5ycdVx.json
+++ b/v1/testdata/url-details-5ycdVx.json
@@ -1,0 +1,5 @@
+{
+ "kind": "urlshortener#url",
+ "id": "https://goo.gl/5ycdVx",
+ "longUrl": "https://medisa.orijtech.com/"
+}

--- a/v1/testdata/url-details-medisa.json
+++ b/v1/testdata/url-details-medisa.json
@@ -1,0 +1,5 @@
+{
+ "kind": "urlshortener#url",
+ "id": "https://goo.gl/5ycdVx",
+ "longUrl": "https://medisa.orijtech.com/"
+}

--- a/v1/testdata/url-details-orijtech.json
+++ b/v1/testdata/url-details-orijtech.json
@@ -1,0 +1,5 @@
+{
+ "kind": "urlshortener#url",
+ "id": "https://goo.gl/Zu6ATj",
+ "longUrl": "https://orijtech.com/"
+}


### PR DESCRIPTION
Implemented an API client to interact
with Google's URL shortening APIs.

The client has three methods:
* Shorten
* Expand
* LookupAnalytics

Sample usage is:

* Preamble:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/googshorty/v1"
)
```

* Shorten a URL
```go
func main() {
	client, err := googshorty.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	details, err := client.Shorten("https://github.com/orijtech/googshorty")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("ShortURL: %q\n", details.ShortURL)
}
```

* Expand a shortened URL
```go
func main() {
	client, err := googshorty.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	details, err := client.Expand("https://goo.gl/XRdHKo")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("LongURL: %q\n", details.LongURL)
}
```

* Lookup analytics for a shortened URL
```go
func main() {
	client, err := googshorty.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	details, err := client.LookupAnalytics("https://goo.gl/XRdHKo")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Analytics: %#v\n", details)
	if analytics := details.Analytics; analytics != nil {
		fmt.Printf("AllTime: %#v\n", analytics.AllTime)
		fmt.Printf("In Last Month: %#v\n", analytics.AllTime)
		fmt.Printf("In Last Week: %#v\n", analytics.WithinLastWeek)
		fmt.Printf("In Last Day: %#v\n", analytics.WithinLastDay)
		fmt.Printf("In Last Two hours: %#v\n", analytics.WithinLast2Hours)
	}
}
```